### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 services:
-  reVCDOS:
+  revcdos:
     hostname: reVCDOS
     build:
       context: .


### PR DESCRIPTION
FIX: Service names are expected to be lowercase characters else they throw an invalid reference format error